### PR TITLE
Improve `gather_data.py` to deal with more complex BIDS datasets

### DIFF
--- a/src/bcm/utils/gather_data.py
+++ b/src/bcm/utils/gather_data.py
@@ -15,7 +15,8 @@ def main(args):
     Gather only relevant data for the benchmark.
     '''
     bids_dir = args.datapath # The data need to use BIDS convention
-    label_suffix = args.suffix_label
+    label_disc_suffix = args.suffix_label_disc
+    seg_suffix = args.suffix_seg
     img_suffix = args.suffix_img
     destination_path = args.output_folder
     contrasts = ['T1w', 'T2w']
@@ -28,7 +29,7 @@ def main(args):
     
     list_dir = os.listdir(bids_dir)
     Total = 0
-    for sub in len(list_dir):
+    for sub in list_dir:
         if sub.startswith('sub'):
             if 'anat' not in os.listdir(os.path.join(bids_dir, sub)): # Check if sessions are provided in BIDS
                 sessions = os.listdir(os.path.join(bids_dir, sub))
@@ -40,21 +41,30 @@ def main(args):
                         print(f"Processing subject {sub} during session {ses} with {contrast} contrast")
                     else:
                         print(f"Processing subject {sub} with {contrast} contrast")
-                    ## Copy the disc label   
-                    src1, img1 = create_path(bids_folder=derivatives_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix=label_suffix, ext='.nii.gz')
-                    dst1 = os.path.join(destination_path, sub, img1)  
                     
                     ## Copy the image
-                    src2, img2 = create_path(bids_folder=bids_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix='', ext='.nii.gz')
-                    dst2 = os.path.join(destination_path, sub, img2)
+                    src1, img1 = create_path(bids_folder=bids_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix='', ext='.nii.gz')
+                    dst1 = os.path.join(destination_path, sub, img1)
                     
-                    # Copy image and labels only if both are present in the dataset    
-                    if os.path.exists(src1) and os.path.exists(src2): 
+                    ## Copy the disc label   
+                    src2, img2 = create_path(bids_folder=derivatives_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix=label_disc_suffix, ext='.nii.gz')
+                    dst2 = os.path.join(destination_path, sub, img2)  
+                    
+                    ## Copy the segmentation
+                    src3, img3 = create_path(bids_folder=derivatives_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix=seg_suffix, ext='.nii.gz')
+                    dst3 = os.path.join(destination_path, sub, img3)
+                    
+                    # Copy image and discs labels if both are present in the dataset or if args.img_only is True   
+                    if os.path.exists(src1) and os.path.exists(src2) or args.img_only: 
                         out_path = os.path.join(destination_path, sub)
                         if not os.path.exists(out_path):
                             os.makedirs(out_path)
-                        copyfile(src1, dst1)
-                        copyfile(src2, dst2)
+                        if os.path.exists(src1):
+                            copyfile(src1, dst1)
+                        if os.path.exists(src2):
+                            copyfile(src2, dst2)
+                        if os.path.exists(src3):
+                            copyfile(src3, dst3)
                         Total += 1
                     else:
                         if not os.path.exists(src1):
@@ -65,7 +75,7 @@ def main(args):
                         else:    
                             print(f"{src2} does not exist. Please check --suffix-img. Or if {contrast} exists")
 
-    print(f'Total number of {len(list_dir)} subject in the dataset\n{Total} files with both image and labels were copied')
+    print(f'Total number of {len(derivatives_dir)} subject in the dataset\n{Total} subjects were computed')
 
 
 def create_path(bids_folder, sub, ses='', img_suffix='', contrast='', label_suffix='', ext='.nii.gz'):
@@ -98,9 +108,14 @@ if __name__ == '__main__':
                         help='Path to BIDS data')
     parser.add_argument('-o', '--output-folder', type=str, required=True,
                         help='Path out to output folder')
-    parser.add_argument('--suffix-label', type=str, default='_labels-disc-manual',
-                        help='Specify label suffix example: sub-296085(IMG_SUFFIX)_T2w(LABEL_SUFFIX).nii.gz (default= "_labels-disc-manual")') 
+    parser.add_argument('--img-only', type=bool, default=False,
+                        help='If True all the images will be moved even if discs labels does not exist'
+                        ' If False images and labels will be moved only if both exist')
     parser.add_argument('--suffix-img', type=str, default='',
-                        help='Specify img suffix example: sub-296085(IMG_SUFFIX)_T2w.nii.gz (default= "")') 
+                        help='Specify img suffix example: sub-296085(IMG_SUFFIX)_T2w.nii.gz (default= "")')
+    parser.add_argument('--suffix-label-disc', type=str, default='_labels-disc-manual',
+                        help='Specify disc label suffix example: sub-296085(IMG_SUFFIX)_T2w(LABEL_SUFFIX).nii.gz (default= "_labels-disc-manual")') 
+    parser.add_argument('--suffix-seg', type=str, default='_seg-manual',
+                        help='Specify segmentation label suffix example: sub-296085(IMG_SUFFIX)_T2w(LABEL_SUFFIX).nii.gz (default= "_seg-manual")')  
     
     main(parser.parse_args())

--- a/src/bcm/utils/gather_data.py
+++ b/src/bcm/utils/gather_data.py
@@ -12,52 +12,83 @@ import argparse
 
 def main(args):
     '''
-    Gather only relevant data for the hourglassnetwork.
+    Gather only relevant data for the benchmark.
     '''
-    data_dir = args.datapath # The data need to use BIDS convention
+    bids_dir = args.datapath # The data need to use BIDS convention
     label_suffix = args.suffix_label
     img_suffix = args.suffix_img
     destination_path = args.output_folder
     contrasts = ['T1w', 'T2w']
-    
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir)
-    
-    ADD =  os.path.join(data_dir,"derivatives/labels/")
-    ADD2 = data_dir
+    derivatives_dir =  os.path.join(bids_dir,"derivatives/labels/")
 
-    list_dir = os.listdir(ADD)
+    # Create output folder if does not exist
+    if not os.path.exists(destination_path):
+        print(f'Output folder {destination_path} was created')
+        os.makedirs(destination_path)
+    
+    list_dir = os.listdir(bids_dir)
     Total = 0
-    for idx in range (len(list_dir)):
-        if list_dir[idx].startswith('sub'):
-            for contrast in contrasts:
-                print(f"Processing subject {list_dir[idx]} with {contrast}")
-                ## Copy the disc label   
-                src1 = os.path.join(ADD, list_dir[idx] + '/anat/' + list_dir[idx] + img_suffix + '_' + contrast + label_suffix + '.nii.gz')
-                dst1 = list_dir[idx] + '/' + list_dir[idx] + img_suffix + '_' + contrast + label_suffix +'.nii.gz'  
-                
-                ## Copy the image   
-                src2 = os.path.join(ADD2, list_dir[idx] + '/anat/'+list_dir[idx] + img_suffix + '_' + contrast + '.nii.gz')
-                dst2 = list_dir[idx] + '/' +list_dir[idx] + img_suffix + '_' + contrast + '.nii.gz'           
-                
-                # Copy image and labels only if both are present in the dataset    
-                if os.path.exists(src1) and os.path.exists(src2): 
-                    out_path = os.path.join(destination_path, list_dir[idx])
-                    if not os.path.exists(out_path):
-                        os.makedirs(out_path)
-                    copyfile(src1, os.path.join(destination_path, dst1))
-                    copyfile(src2, os.path.join(destination_path, dst2))
-                    Total += 1
-                else:
-                    if not os.path.exists(src1):
-                        if not os.path.exists(src2):
-                            print(f"{src1} and {src2} does not exist. Please check --suffix-label and --suffix-img. Or if {contrast} exists")
+    for sub in len(list_dir):
+        if sub.startswith('sub'):
+            if 'anat' not in os.listdir(os.path.join(bids_dir, sub)): # Check if sessions are provided in BIDS
+                sessions = os.listdir(os.path.join(bids_dir, sub))
+            else:
+                sessions = ['']
+            for ses in sessions:
+                for contrast in contrasts:
+                    if ses != '':
+                        print(f"Processing subject {sub} during session {ses} with {contrast} contrast")
+                    else:
+                        print(f"Processing subject {sub} with {contrast} contrast")
+                    ## Copy the disc label   
+                    src1, img1 = create_path(bids_folder=derivatives_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix=label_suffix, ext='.nii.gz')
+                    dst1 = os.path.join(destination_path, sub, img1)  
+                    
+                    ## Copy the image
+                    src2, img2 = create_path(bids_folder=bids_dir, sub=sub, ses=ses, img_suffix=img_suffix, contrast=contrast, label_suffix='', ext='.nii.gz')
+                    dst2 = os.path.join(destination_path, sub, img2)
+                    
+                    # Copy image and labels only if both are present in the dataset    
+                    if os.path.exists(src1) and os.path.exists(src2): 
+                        out_path = os.path.join(destination_path, sub)
+                        if not os.path.exists(out_path):
+                            os.makedirs(out_path)
+                        copyfile(src1, dst1)
+                        copyfile(src2, dst2)
+                        Total += 1
+                    else:
+                        if not os.path.exists(src1):
+                            if not os.path.exists(src2):
+                                print(f"{src1} and {src2} does not exist. Please check --suffix-label and --suffix-img. Or if {contrast} exists")
+                            else:    
+                                print(f"{src1} does not exist. Please check --suffix-label. Or if {contrast} exists")
                         else:    
-                            print(f"{src1} does not exist. Please check --suffix-label. Or if {contrast} exists")
-                    else:    
-                        print(f"{src2} does not exist. Please check --suffix-img. Or if {contrast} exists")
+                            print(f"{src2} does not exist. Please check --suffix-img. Or if {contrast} exists")
 
     print(f'Total number of {len(list_dir)} subject in the dataset\n{Total} files with both image and labels were copied')
+
+
+def create_path(bids_folder, sub, ses='', img_suffix='', contrast='', label_suffix='', ext='.nii.gz'):
+    '''
+    This function creates the full path to an image and the image name only
+    :param bids_folder: full path to BIDS directory
+    :param sub: subject name
+    :param ses: session id
+    :param img_suffix: other additional suffix after session
+    :param contrast: MRI contrast
+    :param label_suffix: method suffix for processed images (i.e.: '_seg', '_label_discs')
+    :param ext: image extension
+    '''
+    img_path = os.path.join(bids_folder, sub, ses, 'anat')
+    img_name = sub
+    for info in [ses, img_suffix, contrast, label_suffix]:
+        if info != '':
+            if info.startswith('_'):
+                img_name += info
+            else:
+                img_name += '_' + info
+    return os.path.join(img_path, img_name + ext), img_name + ext
+
     
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Gather image files and vertebral labels in a new directory')


### PR DESCRIPTION
## Description

This PR was created to improve the robustness of the script `gather_data.py`. This script is now able to deal with the presence of sessions in the BIDS dataset.

Some refactoring was also done.

It is also now possible to copy segmentation files to avoid unecessary use of sct_deepseg_sc in the benchmark. The ability to select manual segmentation will also improve the benchmark results thanks to more accurate projections on the spinal cord.